### PR TITLE
Enable Continuous Integration on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: cpp
 before_script: 
- - sudo apt-get install libgmp-dev libboost-dev libxml2-dev liblua5.1-0-dev libsqlite3-dev
+ - sudo apt-get install libgmp-dev libboost-thread-dev libboost-regex-dev libboost-system-dev libboost-filesystem-dev liblua5.1-0-dev
  - cmake .
 script: make


### PR DESCRIPTION
http://travis-ci.org is able to compile otserv master from scratch, checking if the project builds correctly. You can use it to generate fancy images like this one:
[![Build Status](https://secure.travis-ci.org/adakraz/server.png?branch=travisci)](http://travis-ci.org/adakraz/server)

To enable builds, login to travis-ci, you can probably also enable it to prebuild pull requests.
