### PR TITLE
fix build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -257,6 +257,7 @@ SET(SERVER_SOURCES ${SERVER_SOURCES}
 	${CMAKE_CURRENT_SOURCE_DIR}/src/thing.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/tile.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/tools.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/src/town.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/trashholder.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/vocation.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/waitlist.cpp

--- a/src/beds.h
+++ b/src/beds.h
@@ -21,7 +21,7 @@
 #ifndef __OTSERV_BEDS_H__
 #define __OTSERV_BEDS_H__
 
-#include <cstdint>
+#include <stdint.h>
 #include <map>
 #include "item.h"
 

--- a/src/cylinder.h
+++ b/src/cylinder.h
@@ -21,7 +21,7 @@
 #ifndef __OTSERV_CYLINDER_H__
 #define __OTSERV_CYLINDER_H__
 
-#include <cstdint>
+#include <stdint.h>
 #include <map>
 #include "const.h"
 

--- a/src/definitions.h
+++ b/src/definitions.h
@@ -174,7 +174,6 @@ enum passwordType_t{
 	call some of the useful headers.
 */
 #ifdef __OTSERV_CXX0X__
-	#include <cstdint>
 	#include <unordered_map>
 	#include <unordered_set>
 #else

--- a/src/enum.h
+++ b/src/enum.h
@@ -20,7 +20,11 @@
 #define OTSERV_ENUM_H__
 
 #include <assert.h>
+#include <algorithm>
 #include <stdexcept>
+#include <sstream>
+#include <map>
+#include <vector>
 
 class enum_conversion_error : public std::logic_error {
 public:

--- a/src/position.h
+++ b/src/position.h
@@ -21,7 +21,8 @@
 #ifndef __OTSERV_POSITION_H__
 #define __OTSERV_POSITION_H__
 
-#include <cstdint>
+#include <cstdlib>
+#include <stdint.h>
 #include "enums.h"
 
 class Position{

--- a/src/spawn.h
+++ b/src/spawn.h
@@ -21,7 +21,7 @@
 #ifndef __OTSERV_SPAWN_H__
 #define __OTSERV_SPAWN_H__
 
-#include <cstdint>
+#include <stdint.h>
 #include <string>
 #include <list>
 #include <map>

--- a/src/teleport.h
+++ b/src/teleport.h
@@ -21,7 +21,7 @@
 #ifndef __OTSERV_TELEPORT_H__
 #define __OTSERV_TELEPORT_H__
 
-#include <cstdint>
+#include <stdint.h>
 #include "position.h"
 #include "cylinder.h"
 #include "item.h"

--- a/src/thing.h
+++ b/src/thing.h
@@ -22,7 +22,7 @@
 #define __OTSERV_THING_H__
 
 #include <string>
-#include <cstdint>
+#include <stdint.h>
 
 // Forward declaration
 class Cylinder;

--- a/src/town.cpp
+++ b/src/town.cpp
@@ -21,6 +21,8 @@
 #include "town.h"
 #include "singleton.h"
 
+#include <boost/algorithm/string/predicate.hpp>
+
 Town::Town(uint32_t _townid)
 {
 	townid = _townid;

--- a/src/town.h
+++ b/src/town.h
@@ -21,7 +21,7 @@
 #ifndef __OTSERV_TOWN_H__
 #define __OTSERV_TOWN_H__
 
-#include <cstdint>
+#include <stdint.h>
 #include <string>
 #include <map>
 #include "position.h"

--- a/src/trashholder.h
+++ b/src/trashholder.h
@@ -21,7 +21,7 @@
 #ifndef __OTSERV_TRASHHOLDER_H__
 #define __OTSERV_TRASHHOLDER_H__
 
-#include <cstdint>
+#include <stdint.h>
 #include "cylinder.h"
 #include "const.h"
 #include "item.h"

--- a/src/vocation.h
+++ b/src/vocation.h
@@ -21,7 +21,7 @@
 #ifndef __OTSERV_VOCATION_H__
 #define __OTSERV_VOCATION_H__
 
-#include <cstdint>
+#include <stdint.h>
 #include <string>
 #include <map>
 #include "enums.h"


### PR DESCRIPTION
Recent commits have broken the build (see http://travis-ci.org/#!/adakraz/server/builds/2191311 ).
This commit fixes it ( see http://travis-ci.org/#!/adakraz/server/builds/2192409 ).

The errors are caused by:
- missing cstdint header, which is standard only since c++11, which otserv should not require
- lack of includes - here I have no idea why these are required (preceeding commits did not remove them), but adding them (as guided by errors) fixed the build
