### PR TITLE
The indentation used in this block causes it to appear that the damage <= 0 guard is guarded by the first "if" when it is not

### DIFF
--- a/src/actor.cpp
+++ b/src/actor.cpp
@@ -515,12 +515,14 @@ BlockType Actor::blockHit(CombatType combatType, const CombatSource& combatSourc
       elementMod = it->second;
     }
 
-    if(elementMod != 0)
-      damage = (int32_t)std::ceil(damage * ((float)(100 - elementMod) / 100));
-      if(damage <= 0){
-        damage = 0;
-        blockType = BLOCK_DEFENSE;
-      }
+    if(elementMod != 0) {
+      damage = (int32_t)std::ceil(damage * ((float)(100 - elementMod) / 100));  
+    }
+
+    if(damage <= 0){
+      damage = 0;
+      blockType = BLOCK_DEFENSE;
+    }
   }
 
   return blockType;

--- a/src/actor.cpp
+++ b/src/actor.cpp
@@ -515,7 +515,7 @@ BlockType Actor::blockHit(CombatType combatType, const CombatSource& combatSourc
       elementMod = it->second;
     }
 
-    if(elementMod != 0) {
+    if(elementMod != 0){
       damage = (int32_t)std::ceil(damage * ((float)(100 - elementMod) / 100));  
     }
 


### PR DESCRIPTION
The way the indentation was used is misleading and cause compile-time warnings. By using brackets and aligning both flow statements, we can be sure that the `(damage <= 0)` statement isn't being guarded by `(elementMod != 0)`.